### PR TITLE
Don't renderFooterSpacer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class ParallaxScrollView extends Component {
     const background = this._renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground });
     const foreground = this._renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground: renderForeground || renderParallaxHeader });
     const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle });
-    const footerSpacer = this._renderFooterSpacer({ contentBackgroundColor });
+    const footerSpacer = null; //this._renderFooterSpacer({ contentBackgroundColor });
     const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader });
     const scrollElement = renderScrollComponent(scrollViewProps);
 


### PR DESCRIPTION
FooterSpacer creates problem while rendering position absolute body. Provide content height from contentContainerStyle.
